### PR TITLE
Remove ResFile check causing false positive bugcheck

### DIFF
--- a/payload/nw4r/g3d/g3dResFile.S
+++ b/payload/nw4r/g3d/g3dResFile.S
@@ -8,16 +8,3 @@ PATCH_B_START(ResFile_CheckRevision, 0x74c)
     b InvalidRevisionFail
     // Unreachable
 PATCH_B_END(ResFile_CheckRevision, 0x74c)
-
-PATCH_B_START(ResFile_CheckRevision, 0x948)
-    cmpwi r3, 1
-    beqlr // If it's valid, do nothing
-
-    // Failsafe for unlikely revision failures
-    li r3, -1
-    li r4, 0
-    li r5, -1
-    li r6, 0
-    b InvalidRevisionFail
-    // Unreachable
-PATCH_B_END(ResFile_CheckRevision, 0x948)


### PR DESCRIPTION
This check was causing https://ct.wiimm.de/i/5113 to fail to load on SP, even though it loads completely fine with the check removed.