### PR TITLE
Add some initial basic READMEs for different folders in SP

### DIFF
--- a/payload/game/README.md
+++ b/payload/game/README.md
@@ -1,0 +1,6 @@
+# Game
+
+Contains MKW headers and patches with `REPLACE`/`PATCH_*`.
+
+This folder can also be used for new functionality, such as `ui` containing new UI elements, but
+entirely new features should probably be kept to the `sp` folder, if not needing tight coupling.

--- a/payload/game/host_system/README.md
+++ b/payload/game/host_system/README.md
@@ -1,0 +1,3 @@
+# Host System
+
+This folder contains MKW-specific class derives and other specialisations.

--- a/payload/game/host_system/README.md
+++ b/payload/game/host_system/README.md
@@ -1,3 +1,4 @@
 # Host System
 
-This folder contains MKW-specific class derives and other specialisations.
+This folder contains MKW-specific class derives and other specialisations which are (in the stock game)
+stored in the `main.dol` instead of the `StaticR.rel`, unlike the rest of MKW's code.

--- a/payload/platform/README.md
+++ b/payload/platform/README.md
@@ -1,0 +1,5 @@
+# platform
+
+Contains basic C/C++ standard library functions needing implementing.
+
+TODO(GnomedDev): What is the difference between this and `common`?

--- a/payload/sp/README.md
+++ b/payload/sp/README.md
@@ -1,0 +1,5 @@
+# SP - Service Pack
+
+Contains mod specific headers such as new data structures (`CircularBuffer`) or new features (`ThumbnailManager`).
+
+This folder should not contain any `REPLACE` or `PATCH_*` functions, as they are better suited for the game or library folders.


### PR DESCRIPTION
Start off some basic documentation work to help new contributors or existing contributors understand new systems. These READMEs are not intended for deep technical explaination, simply a quick overview to show what to expect in said folder.