### PR TITLE
Remove AlignTrailingComments format option

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -6,7 +6,6 @@ AlignConsecutiveDeclarations: None
 AlignConsecutiveMacros: None
 AlignEscapedNewlines: DontAlign
 AlignOperands: DontAlign
-AlignTrailingComments: True
 AllowAllArgumentsOnNextLine: False
 AllowAllParametersOfDeclarationOnNextLine: False
 AllowShortBlocksOnASingleLine: Empty


### PR DESCRIPTION
This option existing in the config seems to cause clang-format 16 to error with
```
.clang-format:9:24: error: not a mapping
AlignTrailingComments: True
                       ^~~~
Error reading .clang-format: Invalid argument
```