### PR TITLE
Remove now unused Page.h

### DIFF
--- a/payload/game/ui/Page.h
+++ b/payload/game/ui/Page.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include <Common.h>
-
-typedef struct Page {
-    u8 _00[0x44 - 0x00];
-} Page;
-
-static_assert(sizeof(Page) == 0x44);


### PR DESCRIPTION
This was still used after #689 due to `KartObjectManager` and `RacePage`, but now can be safely removed.