### PR TITLE
Improve dol/rel error messages

### DIFF
--- a/loader/Loader.cc
+++ b/loader/Loader.cc
@@ -123,9 +123,7 @@ std::optional<Apploader::GameEntryFunc> Run() {
         return {};
     }
     if (!*isDolClean) {
-        Console::Print(
-                "Please ensure that the file 'main.dol' is not modified\n"
-                "in any capacity!");
+        Console::Print("Please ensure the game disk is not modified in any capacity!");
         return {};
     }
 

--- a/payload/sp/Payload.cc
+++ b/payload/sp/Payload.cc
@@ -165,9 +165,7 @@ static void Init() {
         Console::Print(" failed with reason \"");
         Console::Print(rel_ok.error());
         Console::Print("\"!\n");
-        Console::Print(
-                "Please ensure that the file 'StaticR.rel' exists on the\n"
-                "game disk and that it is not modified in any capacity!\n");
+        Console::Print("Please ensure the game disk is not modified in any capacity!\n");
         Console::Print("Returning to the loader...");
         System::SystemManager::ResetDolphinSpeedLimit();
         OSSleepMilliseconds(10000);


### PR DESCRIPTION
This makes it simple for a user that is not familiar with Wii game patching to understand what is wrong, useful if they think the Wiimmfi patcher is a magic black box.

Closes #755 