### PR TITLE
Fix FixedString's includes

### DIFF
--- a/payload/sp/FixedString.hh
+++ b/payload/sp/FixedString.hh
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <Common.h>
-#include <algorithm>
-#include <array>
-#include <string_view>
-
 extern "C" {
 #include "sp/WideUtil.h"
 }
+
+#include <Common.hh>
+
+#include <algorithm>
+#include <string_view>
 
 namespace SP {
 


### PR DESCRIPTION
This fixes the problem of `Common.h` being included without `extern "C"`, meaning calls to functions like `panic` including C++ name mangling and therefore failing.