### PR TITLE
Implement a Rust-like macro for TRY on std::optional

### DIFF
--- a/common/ES.hh
+++ b/common/ES.hh
@@ -2,8 +2,6 @@
 
 #include "IOS.hh"
 
-#include <optional>
-
 namespace IOS {
 
 class ES final : private Resource {

--- a/common/FS.hh
+++ b/common/FS.hh
@@ -2,8 +2,6 @@
 
 #include "IOS.hh"
 
-#include <optional>
-
 namespace IOS {
 
 class FS final : private Resource {

--- a/include/Common.hh
+++ b/include/Common.hh
@@ -7,6 +7,7 @@ extern "C" {
 }
 
 #include <array>
+#include <optional>
 #include <type_traits>
 #include <utility>
 
@@ -94,4 +95,16 @@ template <typename T> auto MyMove(T&& t) {
 #else
 #define TRY(...) static_assert(false, "Compiler does not support TRY macro")
 #endif
+
+template <typename T>
+void RequireOpt(std::optional<T>) {}
+
+#define TRY_OPT(opt) ({ \
+    auto y = (opt); \
+    RequireOpt(y); \
+    if (!y.has_value()) [[unlikely]] { \
+        return std::nullopt; \
+    } \
+    *y; \
+})
 // clang-format on

--- a/loader/Apploader.hh
+++ b/loader/Apploader.hh
@@ -2,8 +2,6 @@
 
 #include "DI.hh"
 
-#include <optional>
-
 namespace Apploader {
 
 typedef void (*GameEntryFunc)(void);

--- a/loader/Dol.hh
+++ b/loader/Dol.hh
@@ -2,8 +2,6 @@
 
 #include <Common.hh>
 
-#include <optional>
-
 namespace Dol {
 
 const void *GetStartAddress();

--- a/payload/game/system/GhostFile.hh
+++ b/payload/game/system/GhostFile.hh
@@ -6,8 +6,6 @@
 
 #include <sp/ShaUtil.hh>
 
-#include <optional>
-
 namespace System {
 
 static const u32 MAX_GHOST_COUNT = 4096;

--- a/payload/game/system/RaceConfig.hh
+++ b/payload/game/system/RaceConfig.hh
@@ -6,8 +6,6 @@
 #include <sp/FixedString.hh>
 #include <sp/ShaUtil.hh>
 
-#include <optional>
-
 namespace System {
 
 /// Configuration for the current race.

--- a/payload/game/ui/MultiTeamSelectPage.hh
+++ b/payload/game/ui/MultiTeamSelectPage.hh
@@ -6,8 +6,6 @@
 #include "game/ui/ctrl/CtrlMenuBackButton.hh"
 #include "game/ui/ctrl/CtrlMenuPageTitleText.hh"
 
-#include <optional>
-
 namespace UI {
 
 class MultiTeamSelectPage : public Page {

--- a/payload/game/ui/ScrollBar.hh
+++ b/payload/game/ui/ScrollBar.hh
@@ -3,8 +3,6 @@
 #include "game/ui/MenuInputManager.hh"
 #include "game/ui/UIControl.hh"
 
-#include <optional>
-
 namespace UI {
 
 class ScrollBar : public LayoutUIControl {

--- a/payload/sp/Channel.cc
+++ b/payload/sp/Channel.cc
@@ -11,7 +11,6 @@ extern "C" {
 #include <array>
 #include <cstdio>
 #include <cstring>
-#include <optional>
 
 namespace SP::Channel {
 

--- a/payload/sp/CircularBuffer.hh
+++ b/payload/sp/CircularBuffer.hh
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 #include <Common.hh>
 
 namespace SP {

--- a/payload/sp/CourseDatabase.hh
+++ b/payload/sp/CourseDatabase.hh
@@ -2,8 +2,6 @@
 
 #include <game/util/Registry.hh>
 
-#include <optional>
-
 namespace SP {
 
 class CourseDatabase {

--- a/payload/sp/Exchange.hh
+++ b/payload/sp/Exchange.hh
@@ -6,8 +6,6 @@ extern "C" {
 #include <revolution.h>
 }
 
-#include <optional>
-
 namespace SP {
 
 struct Empty {

--- a/payload/sp/ItemCommand.hh
+++ b/payload/sp/ItemCommand.hh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Common.hh>
-#include <optional>
 
 namespace SP {
 

--- a/payload/sp/MapFile.cc
+++ b/payload/sp/MapFile.cc
@@ -19,7 +19,6 @@ extern "C" {
 #include <cmath>
 #include <cstdio>
 #include <ctype.h>
-#include <optional>
 #include <string_view>
 
 namespace SP::MapFile {

--- a/payload/sp/MapFile.hh
+++ b/payload/sp/MapFile.hh
@@ -2,7 +2,6 @@
 
 #include <Common.hh>
 
-#include <optional>
 #include <string_view>
 
 namespace SP::MapFile {

--- a/payload/sp/SaveStateManager.hh
+++ b/payload/sp/SaveStateManager.hh
@@ -2,8 +2,6 @@
 
 #include "game/kart/KartSaveState.hh"
 
-#include <optional>
-
 namespace SP {
 
 class SaveStateManager {

--- a/payload/sp/Update.hh
+++ b/payload/sp/Update.hh
@@ -4,8 +4,6 @@ extern "C" {
 #include <libhydrogen/hydrogen.h>
 }
 
-#include <optional>
-
 #include <Common.hh>
 
 namespace SP::Update {

--- a/payload/sp/YAZDecoder.hh
+++ b/payload/sp/YAZDecoder.hh
@@ -4,8 +4,6 @@
 
 #include <egg/core/eggHeap.hh>
 
-#include <optional>
-
 namespace SP {
 
 class YAZDecoder : public Decoder {

--- a/payload/sp/net/SyncSocket.hh
+++ b/payload/sp/net/SyncSocket.hh
@@ -4,8 +4,6 @@ extern "C" {
 #include <libhydrogen/hydrogen.h>
 }
 
-#include <optional>
-
 #include <Common.hh>
 
 namespace SP::Net {

--- a/payload/sp/net/UnreliableSocket.hh
+++ b/payload/sp/net/UnreliableSocket.hh
@@ -5,8 +5,6 @@ extern "C" {
 #include <revolution.h>
 }
 
-#include <optional>
-
 #include <Common.hh>
 
 namespace SP::Net {

--- a/payload/sp/settings/IniReader.hh
+++ b/payload/sp/settings/IniReader.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <optional>
 #include <string_view>
 
 #include <Common.hh>

--- a/payload/sp/storage/Storage.hh
+++ b/payload/sp/storage/Storage.hh
@@ -7,7 +7,6 @@ extern "C" {
 }
 
 #include <cwchar>
-#include <optional>
 
 namespace SP::Storage {
 

--- a/stub/Archive.hh
+++ b/stub/Archive.hh
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <optional>
 #include <variant>
 
 #include <Common.hh>

--- a/stub/LZMA.hh
+++ b/stub/LZMA.hh
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <optional>
-
 #include <Common.hh>
 
 namespace LZMA {


### PR DESCRIPTION
Turns out this actually reduces line count because we get to remove all the `#include <optional>`