### PR TITLE
Fix startup time of debug build updateserver

### DIFF
--- a/tools/updateserver/Cargo.toml
+++ b/tools/updateserver/Cargo.toml
@@ -14,3 +14,7 @@ zeroize = "1.5.5"
 
 [build-dependencies]
 prost-build = "0.10.4"
+
+# Startup password hashing will take insane amounts of time otherwise.
+[profile.dev.package.argon2]
+opt-level = 3


### PR DESCRIPTION
This forces updateserver's argon2 dependency to always be built with optimizations, preventing insanely slow startup times due to password hashing.