### PR TITLE
Create /mkw-sp/licenses/ earlier on

### DIFF
--- a/payload/game/system/SaveManager.cc
+++ b/payload/game/system/SaveManager.cc
@@ -76,14 +76,15 @@ void SaveManager::initSPSave() {
     // TODO: Hopefully this is enough. Can always stream the file if not.
     char iniBuffer[2048];
 
+    SP::Storage::CreateDir(L"/mkw-sp/licenses", true);
     for (m_spLicenseCount = 0; m_spLicenseCount < std::size(m_spLicenses);) {
         wchar_t path[64], pathOld[64];
         swprintf(pathOld, std::size(pathOld), L"/mkw-sp/settings%u.ini", m_spLicenseCount);
         swprintf(path, std::size(path), L"/mkw-sp/licenses/slot%u.ini", m_spLicenseCount);
 
         bool oldLicenseExists = static_cast<bool>(SP::Storage::Open(pathOld, "r"));
+
         if (oldLicenseExists) {
-            SP::Storage::CreateDir(L"/mkw-sp/licenses", true);
             SP::Storage::Rename(pathOld, path);
         }
         auto size = SP::Storage::ReadFile(path, iniBuffer, sizeof(iniBuffer));


### PR DESCRIPTION
failed if the user had no saves :P
```cc
// SaveManager::initSPSave()
if (oldLicenseExists /* false */ ) { SP::Storage::CreateDir(/* ... */) }
```
```cc
// SaveManager::saveSPSave()
if (!SP::Storage::WriteFile(path, /* ... */) { // <-- false because /mkw-sp/licenses/ does not exist
```