### PR TITLE
Try mount SD first(?)

### DIFF
--- a/payload/sp/storage/FATStorage.cc
+++ b/payload/sp/storage/FATStorage.cc
@@ -37,7 +37,7 @@ FATStorage::FATStorage() {
         m_dirs[i].m_storage = this;
     }
 
-    std::array initFuncs{UsbStorage_init, SdiStorage_init};
+    std::array initFuncs{SdiStorage_init, UsbStorage_init};
 
     for (auto initFunc : initFuncs) {
         if (!initFunc(&s_storage)) {


### PR DESCRIPTION
This one feels kind of funny because. It took me 18 tries for mkw-sp to pick USB instead of SD 5 times. Of course with this single line edit, it would mount my USB a grand total of 0 times out of those same 18. However i'm just surprised that it mounted my USB only... 5 times. I guess it's just Dolphin